### PR TITLE
Insights report

### DIFF
--- a/rest-service/manager_rest/config.py
+++ b/rest-service/manager_rest/config.py
@@ -49,6 +49,8 @@ class Config(object):
         self.max_results = 1000
         self.min_available_memory_mb = None
 
+        self.insights_report_url = None
+
         self.security_hash_salt = None
         self.security_secret_key = None
         self.security_encoding_alphabet = None

--- a/rest-service/manager_rest/flask_utils.py
+++ b/rest-service/manager_rest/flask_utils.py
@@ -75,6 +75,13 @@ def get_postgres_conf(manager_ip='localhost'):
     )
 
 
+def get_insights_report_url():
+    """Return the URL used to fetch the Insights report"""
+    manager_config.load_configuration()
+    url = manager_config.insights_report_url or 'https://mist.io/'
+    return url.strip('/') + '/api/v1/report'
+
+
 def set_flask_security_config(app, hash_salt=None, secret_key=None):
     """Set all necessary Flask-Security configurations
 

--- a/rest-service/manager_rest/rest/endpoint_mapper.py
+++ b/rest-service/manager_rest/rest/endpoint_mapper.py
@@ -81,7 +81,8 @@ def setup_resources(api):
         'FileServerAuth': 'file-server-auth',
         'LdapAuthentication': 'ldap',
         'Secrets': 'secrets',
-        'SecretsKey': 'secrets/<string:key>'
+        'SecretsKey': 'secrets/<string:key>',
+        'InsightsReport': 'report',
     }
 
     # Set version endpoint as a non versioned endpoint

--- a/rest-service/manager_rest/rest/resources_v1/__init__.py
+++ b/rest-service/manager_rest/rest/resources_v1/__init__.py
@@ -44,3 +44,5 @@ from .search import Search  # noqa
 from .status import Status  # noqa
 from .tokens import Tokens  # noqa
 from .version import Version  # noqa
+
+from .report import InsightsReport

--- a/rest-service/manager_rest/rest/resources_v1/report.py
+++ b/rest-service/manager_rest/rest/resources_v1/report.py
@@ -22,6 +22,8 @@ from manager_rest.storage import get_storage_manager
 
 from manager_rest.security import SecuredResource
 
+from manager_rest.flask_utils import get_insights_report_url
+
 from manager_rest.manager_exceptions import NotFoundError
 from manager_rest.manager_exceptions import ManagerException
 from manager_rest.manager_exceptions import UnauthorizedError
@@ -38,7 +40,7 @@ class InsightsReport(SecuredResource):
         Get the Insights report
         """
         token = get_storage_manager().get(models.Secret, 'insights_token')
-        report = requests.get('https://mist.io/api/v1/report',
+        report = requests.get(get_insights_report_url(),
                               params=request.args,
                               headers={'Authorization': token.value})
         if not report.ok:

--- a/rest-service/manager_rest/rest/resources_v1/report.py
+++ b/rest-service/manager_rest/rest/resources_v1/report.py
@@ -1,0 +1,52 @@
+#########
+# Copyright (c) 2017 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+#
+import requests
+
+from flask import request
+
+from manager_rest.storage import models
+from manager_rest.storage import get_storage_manager
+
+from manager_rest.security import SecuredResource
+
+from manager_rest.manager_exceptions import NotFoundError
+from manager_rest.manager_exceptions import ManagerException
+from manager_rest.manager_exceptions import UnauthorizedError
+from manager_rest.manager_exceptions import BadParametersError
+
+from manager_rest.rest.rest_decorators import exceptions_handled
+
+
+class InsightsReport(SecuredResource):
+
+    @exceptions_handled
+    def get(self):
+        """
+        Get the Insights report
+        """
+        token = get_storage_manager().get(models.Secret, 'insights_token')
+        report = requests.get('https://mist.io/api/v1/report',
+                              params=request.args,
+                              headers={'Authorization': token.value})
+        if not report.ok:
+            if report.status_code == 400:
+                raise BadParametersError()
+            if report.status_code == 401:
+                raise UnauthorizedError()
+            if report.status_code == 404:
+                raise NotFoundError()
+            raise ManagerException(report.status_code, 'insights_report_error')
+        return report.json()


### PR DESCRIPTION
Introduces a new API endpoint that'll proxy requests for Insights to the Mist.io SaaS

- The new endpoint has been implemented under `/api/v1/` for compatibility with the Mist.io API
- Additionally, the remote API endpoint used to fetch the Insights report is configurable through the `insights_report_url` option

See related nginx conf: https://github.com/pchristos/cloudify-manager-blueprints/pull/1/files